### PR TITLE
mastodon-dailyのcron設定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ pip install ansible
    - `lets_encrypt_admin_email` : let's encrypt に登録する管理者のメールアドレス。
    - `smtp_*` : smtp関連の設定。現在はGmail用の設定を書いています。Gmailを使う場合はメールアドレスだけ書き換えればOKです。
    - `ntp_servers` : ntpサーバ名。
+   - `mastodon_daily_cron_timing`: デフォルトは `17 4 * * *` としていますが適宜変更してください。
 * `passwords.ini.sample` を `password.ini` にコピーしてパスワードを変更する
    - `db_password` : PostgreSQLのmastodonユーザのパスワード。
    - `smtp_password` : smtpサーバに接続するときのパスワード。Gmailで2段階認証を使っている場合は[アプリ パスワードでログイン - Gmail ヘルプ](https://support.google.com/mail/answer/185833?hl=ja)を参照してアプリパスワードを生成して指定してください。

--- a/group_vars/vps/vars.yml
+++ b/group_vars/vps/vars.yml
@@ -15,6 +15,7 @@ lets_encrypt_config_dir: /etc/letsencrypt
 lets_encrypt_lego_version: 0.3.1
 lets_encrypt_tarball_url: https://github.com/xenolf/lego/releases/download/v{{ lets_encrypt_lego_version }}/lego_linux_amd64.tar.xz
 
+mastodon_daily_cron_timing: "17 4 * * *"
 mastodon_app_dir: /home/mastodon/live
 mastodon_app_git_version: master
 production_env_path: "{{ mastodon_app_dir }}/.env.production"

--- a/roles/mastodon/tasks/cron.yml
+++ b/roles/mastodon/tasks/cron.yml
@@ -1,0 +1,13 @@
+---
+- name: Write mastodon daily script file
+  template:
+    src: mastodon-daily.sh.j2
+    dest: /usr/local/sbin/mastodon-daily.sh
+    owner: mastodon
+    group: mastodon
+    mode: 0755
+
+- name: Write mastodon daily cron file
+  template:
+    src: mastodon-daily.cron.j2
+    dest: /etc/cron.d/mastodon-daily

--- a/roles/mastodon/tasks/main.yml
+++ b/roles/mastodon/tasks/main.yml
@@ -35,3 +35,8 @@
   tags:
     - mastodon
     - streaming
+
+- include: cron.yml
+  tags:
+    - mastodon
+    - mastodon_cron

--- a/roles/mastodon/templates/mastodon-daily.cron.j2
+++ b/roles/mastodon/templates/mastodon-daily.cron.j2
@@ -1,0 +1,2 @@
+MAILTO=root
+{{ mastodon_daily_cron_timing }} mastodon /usr/local/sbin/mastodon-daily.sh

--- a/roles/mastodon/templates/mastodon-daily.sh.j2
+++ b/roles/mastodon/templates/mastodon-daily.sh.j2
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -eu
+
+log() {
+  local priority=$1
+  shift
+  logger -t mastodon-daily -p "$priority" "$@"
+}
+
+elapsed_since() {
+  local elapsed=$(($SECONDS - $1))
+  echo "$(($elapsed/60))m$(($elapsed%60))s"
+}
+
+run_task() {
+  local task=$1
+  local start=$SECONDS
+  log user.info $task started.
+  cd "{{ mastodon_app_dir }}" && /home/mastodon/.rbenv/shims/bundle exec rake $task | log user.info
+  local elapsed_seconds=$(($SECONDS - $start))
+  local elapsed=$(($elapsed_seconds/60))m$(($elapsed_seconds%60))s
+  log user.info $task finished, elapsed=$elapsed.
+}
+
+RAILS_ENV=production
+export RAILS_ENV
+
+# https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Production-guide.md#cronjobs
+# https://github.com/tootsuite/mastodon/blob/8565ba68f7a6e4342cd4a63833b4d0ff743f0235/lib/tasks/mastodon.rake#L5-L11
+# http://qiita.com/clworld/items/bc3d8f97d38f2ba58492
+
+log user.info mastodon-daily start.
+run_task mastodon:feeds:clear
+run_task mastodon:media:clear
+run_task mastodon:users:clear
+run_task mastodon:push:refresh
+log user.info mastodon-daily finished.


### PR DESCRIPTION
[Mastodonのサーバ間通信が切れた場合のリカバリ - Qiita](http://qiita.com/clworld/items/bc3d8f97d38f2ba58492#%E8%BF%BD%E8%A8%983-cron%E3%81%AF%E5%BF%85%E3%81%9A%E5%9B%9E%E3%81%9B%E7%B5%B6%E5%AF%BE%E5%9B%9E%E3%81%9Bdocker%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6%E3%81%A6%E3%82%82%E8%87%AA%E5%8B%95%E3%81%A7%E3%81%AF%E8%A8%AD%E5%AE%9A%E3%81%97%E3%81%A6%E3%81%8F%E3%82%8C%E3%81%AA%E3%81%84%E3%81%AE%E3%81%A7%E8%A8%AD%E5%AE%9A%E3%81%99%E3%81%B9%E3%81%97)
によると
[Cronjobs](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Production-guide.md#cronjobs)
に書かれている `mastodon:daily` タスクを直接実行するとメモリ1GBだとメモリ不足で落ちることがあるそうなので、
https://github.com/tootsuite/mastodon/blob/8565ba68f7a6e4342cd4a63833b4d0ff743f0235/lib/tasks/mastodon.rake#L5-L11
のタスクを個別に実行しています。

それぞれのタスクを別のcronジョブにすると時間がかぶる可能性があるので、シェルスクリプトを作って、その中で順次実行するようにしました。

また
[cron で > /dev/null して椅子を投げられないための3つの方法 - 酒日記 はてな支店](http://sfujiwara.hatenablog.com/entry/20120613/1339547638)
を参考にログはsyslogに出すようにしました。

実行中に

```
journalctl -e -f -t mastodon-daily
```
のように実行すれば `tail -f` っぽい感じでログが見られます。
