### PR TITLE
sshdのパスワード認証を禁止する

### DIFF
--- a/roles/sshd_config/tasks/config.yml
+++ b/roles/sshd_config/tasks/config.yml
@@ -2,12 +2,12 @@
 - name: Disable ssh password login
   lineinfile:
     path: /etc/ssh/sshd_config
-    insertafter: "#PermitEmptyPasswords yes"
-    line: "PermitEmptyPasswords no"
-  register: sshd_config_ret
+    insertafter: "#PasswordAuthentication yes"
+    line: "PasswordAuthentication no"
+  register: sshd_config_password_auth_ret
 
 - name: Reload sshd
   systemd:
     name: sshd
     state: reloaded
-  when: sshd_config_ret.changed
+  when: sshd_config_password_auth_ret.changed


### PR DESCRIPTION
間違って `PasswordAuthentication` ではなく `PermitEmptyPasswords` の設定を変えていたのを修正。

```
ansible-playbook vps-firsttime.yml -t sshd_config -v -D -C -K
```

で適用してください。